### PR TITLE
Added CPOL/CPHA mode setting into SPI driver initialization function.

### DIFF
--- a/rflpc17xx/drivers/spi.c
+++ b/rflpc17xx/drivers/spi.c
@@ -38,7 +38,7 @@
 #define MISO1_PIN  RFLPC_PIN_P0_8
 #define MOSI1_PIN  RFLPC_PIN_P0_9
 
-void rflpc_spi_init(rflpc_spi_t port, rflpc_spi_mode_t mode, rflpc_clock_divider_t cpu_clock_divider, uint8_t data_size_transfert, uint8_t clock_prescale, uint8_t serial_clock_rate)
+void rflpc_spi_init(rflpc_spi_t port, rflpc_spi_mode_t mode, rflpc_clock_divider_t cpu_clock_divider, uint8_t data_size_transfert, uint8_t clock_prescale, uint8_t serial_clock_rate, uint8_t clock_polarity_phase)
 {
    LPC_SSP_TypeDef *spi_base = rflpc_spi_get_base_addr(port);
    
@@ -66,6 +66,14 @@ void rflpc_spi_init(rflpc_spi_t port, rflpc_spi_mode_t mode, rflpc_clock_divider
 
    /* user manual p. 422. Set the data transfert size */
    spi_base->CR0 = ((data_size_transfert - 1) & 0xF);
+
+   /* Set CPHA = 1 if needed */
+   if (clock_polarity_phase & 0x01)
+     RFLPC_SET_BIT(spi_base->CR0, 7);
+   /* Set CPOL = 1 if needed */
+   if (clock_polarity_phase & 0x02)
+     RFLPC_SET_BIT(spi_base->CR0, 6);
+
    /* No loop back, enable ssp controler */
    spi_base->CR1 = (1UL << 1);
    if (mode == RFLPC_SPI_SLAVE)

--- a/rflpc17xx/drivers/spi.h
+++ b/rflpc17xx/drivers/spi.h
@@ -57,12 +57,13 @@ typedef enum
  * @param data_size_transfert the number of bits that are transfered in each frame (only values between 4 and 16bits are supported)
  * @param clock_prescale Factor by which the prescaler divide the peripheral clock. Between 2 and 254. Bit 0 is always read as 0 (only even numbers). Used only for master mode
  * @param serial_clock_rate Number of prescaler-outputs ber bit. This allows to set the SPI tranfert clock. Used only for master mode. 
+ * @param clock_polarity_phase Clock polarity and phase. CPOL is bit 1, CPHA is bit 0. Other bits are ignored.
  *
  * @note The final clock used as SCK is then \f[\frac{CPU Clock}{CPUDivider \times ClockPrescale \times SerialClockRate}\f]
  *       In slave mode, the clock_prescale and serial_clock_rate parameters are not used. The clock sent by the master must not exceed 1/12 of the frequency used to clock the SPI peripheral
  * @see ::rflpc_clock_get_system_clock()
  **/
-extern void rflpc_spi_init(rflpc_spi_t port, rflpc_spi_mode_t mode, rflpc_clock_divider_t cpu_clock_divider, uint8_t data_size_transfert, uint8_t clock_prescale, uint8_t serial_clock_rate);
+extern void rflpc_spi_init(rflpc_spi_t port, rflpc_spi_mode_t mode, rflpc_clock_divider_t cpu_clock_divider, uint8_t data_size_transfert, uint8_t clock_prescale, uint8_t serial_clock_rate, uint8_t clock_polarity_phase);
 
 /**
  * Returns the base address of the SPI control block depending of the desired port

--- a/samples/spi-leds/main.c
+++ b/samples/spi-leds/main.c
@@ -61,7 +61,7 @@ void test_spi()
    needed_divider /= serial_clock_rate_divider;
    printf("Computed clock: %d (%d %d) \r\n", spi_peripheral_clock / (needed_divider * serial_clock_rate_divider), needed_divider, serial_clock_rate_divider);
 
-   rflpc_spi_init(SPI_PORT, RFLPC_SPI_MASTER, RFLPC_CCLK_8, 8, needed_divider, serial_clock_rate_divider);
+   rflpc_spi_init(SPI_PORT, RFLPC_SPI_MASTER, RFLPC_CCLK_8, 8, needed_divider, serial_clock_rate_divider, 0);
 
    
    for (i = 0 ; i < 64 ; ++i)

--- a/samples/spi-simple/main.c
+++ b/samples/spi-simple/main.c
@@ -75,9 +75,9 @@ int main()
     configure_timer();
     printf("SPI simple sample build on %s %s\r\n", __DATE__, __TIME__);
     /* Init master SPI, set the SPI clock to 12 Mhz / (60*2) = 100 kHz */
-    rflpc_spi_init(MASTER_SPI, RFLPC_SPI_MASTER, RFLPC_CCLK_8, 8, 60, 2);
+    rflpc_spi_init(MASTER_SPI, RFLPC_SPI_MASTER, RFLPC_CCLK_8, 8, 60, 2, 0);
     /* Init slave SPI */
-    rflpc_spi_init(SLAVE_SPI, RFLPC_SPI_SLAVE, RFLPC_CCLK_8, 8, 0, 0);
+    rflpc_spi_init(SLAVE_SPI, RFLPC_SPI_SLAVE, RFLPC_CCLK_8, 8, 0, 0, 0);
     
     if (use_interrupt)
     {


### PR DESCRIPTION
Salut Michael, voici la petite modification du code du driver SPI. J'ai juste rajouté un paramètre à la fonction d'initialisation, qui permet via les deux bits de poids faibles de régler le mode de polarité/phase d'horloge. J'ai mis à jour les samples utilisant la fonction, en rajoutant un 0 non significatif afin d'éviter les erreurs à la compilation.
